### PR TITLE
T-8563: Fix for Ordering on Columns with NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,53 @@ const thirdResult = await Counter.paginate({
 });
 ```
 
+## Ordering Columns With Null Values
+The creation of cursor for pagination depends on primary key. But, when primary ordering is required on another column and if it happens to contain null values, the pagination query doesn't work as expected. This happens as `lt`, `gt` dont get applied to null values. We have added logic to take care of this scenario.
+
+A sample of the pagination where clause that gets appended to the main query is provided below,
+
+**Note**: Considered a boolean column `isTracked` on which primary ordering is expected.
+
+### Descending 
+Order: [null -> true -> false]
+
+If `cursor[0]` is null, we need to make a union of all results that are greater than
+the primary key and all the non-null values.
+
+```javascript
+where: {
+  [Op.or]: [
+    { isTracked: { [Op.ne]: null } },
+    {
+      isTracked: null,
+      pk: { [Op.gt]: 'ed1a5338-7620-4386-9501-85ea08e04a37' }
+    }
+  ]
+}
+```
+### Ascending
+
+Order: [false -> true -> null]
+
+If cursor[0] is non-null, we need to make a union of all results that are less than the primary key and all the null values + greater than the column value filter (false in the below sample).
+
+```javascript
+where: {
+  [Op.or]: [
+    {
+      isTracked: {
+          [Op.or]: [ { [Op.is]: null }, { [Op.gt]: false } ]
+        },
+      },
+      { 
+        isTracked: false,
+        pk: { [Op.lt]: 'ed1a5338-7620-4386-9501-85ea08e04a37'
+      }
+    }
+  ]
+}
+```
+
 ## Running tests
 
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const withPagination =
       methodName = 'paginate',
       primaryKeyField = 'id',
       omitPrimaryKeyFromOrder = false,
+      enforceNullOrder = true,
     } = options;
 
     const paginate = async ({
@@ -30,7 +31,7 @@ const withPagination =
         omitPrimaryKeyFromOrder,
       );
 
-      order = before ? reverseOrder(order) : order;
+      order = before ? reverseOrder(order, enforceNullOrder) : order;
 
       const cursor = after
         ? parseCursor(after)

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ const normalizeOrder = (order, primaryKeyField, omitPrimaryKeyFromOrder) => {
 const reverseOrder = (order) => {
   return order.map((orderItem) => {
     orderItem[orderItem.length - 1] =
-      orderItem[orderItem.length - 1].toLowerCase() === 'desc' ? 'ASC' : 'DESC';
+      orderItem[orderItem.length - 1].toLowerCase().split(' ')[0] === 'desc' ? 'ASC' : 'DESC';
     return orderItem;
   });
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,7 +99,7 @@ const isValidCursor = (cursor, order) => {
 const recursivelyGetPaginationQuery = (order, cursor) => {
   const directionValueIndex = order[0].length - 1;
   // if cursor[0] is null then we set a not equal operator
-  const currentOp = cursor[0] ? (order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt) : Op.ne;
+  const currentOp = cursor[0] === null ? (order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt) : Op.ne;
 
   // supporting only below format
   // [

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,7 +99,7 @@ const isValidCursor = (cursor, order) => {
 const recursivelyGetPaginationQuery = (order, cursor) => {
   const directionValueIndex = order[0].length - 1;
   // if cursor[0] is null then we set a not equal operator
-  const currentOp = cursor[0] === null ? (order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt) : Op.ne;
+  const currentOp = cursor[0] === null ? Op.ne : order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt;
 
   // supporting only below format
   // [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,8 @@
 let { Op } = require('sequelize');
 
+const ASC_NULLS_LAST = 'ASC NULLS LAST'
+const DESC_NULLS_FIRST = 'DESC NULLS FIRST'
+
 if (!Op) {
   // Support older versions of sequelize
   Op = {
@@ -67,10 +70,10 @@ const reverseOrder = (order, enforceNullOrder) => {
   return order.map((orderItem) => {
     const keyIndexToUpdate = orderItem.length - 1
     if(orderItem[keyIndexToUpdate].toLowerCase().split(' ')[0] === 'desc') {
-      orderItem[keyIndexToUpdate] = enforceNullOrder ? 'ASC NULLS LAST' : 'ASC'
+      orderItem[keyIndexToUpdate] = enforceNullOrder ? ASC_NULLS_LAST : 'ASC'
       return orderItem;
     }
-    orderItem[keyIndexToUpdate] = enforceNullOrder ? 'DESC NULLS FIRST' : 'DESC'
+    orderItem[keyIndexToUpdate] = enforceNullOrder ? DESC_NULLS_FIRST : 'DESC'
     return orderItem;
   });
 };
@@ -139,11 +142,11 @@ const recursivelyGetPaginationQuery = (order, cursor) => {
     const key = _getColumnName(order);
 
     // https://github.com/goSprinto/sequelize-cursor-pagination#ordering-columns-with-null-values
-    if(cursor[0] === null &&  orderValue === 'DESC NULLS FIRST') {
+    if(cursor[0] === null &&  orderValue === DESC_NULLS_FIRST) {
       operatorFilter = { [Op.ne]: cursor[0] }
     }
   
-    if(cursor[0] !== null && orderValue === 'ASC NULLS LAST') {
+    if(cursor[0] !== null && orderValue === ASC_NULLS_LAST) {
       operatorFilter = {[Op.or]: [{[Op.is]: null}, operatorFilter] }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,8 +98,8 @@ const isValidCursor = (cursor, order) => {
 
 const recursivelyGetPaginationQuery = (order, cursor) => {
   const directionValueIndex = order[0].length - 1;
-  const currentOp =
-    order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt;
+  // if cursor[0] is null then we set a not equal operator
+  const currentOp = cursor[0] ? (order[0][directionValueIndex].toLowerCase().split(' ')[0] === 'desc' ? Op.lt : Op.gt) : Op.ne;
 
   // supporting only below format
   // [


### PR DESCRIPTION
Applying less than `lt` or greater than `gt` operators on null values doesn't work. Hence, we're using `ne` to retrieve the expected paginated results.