### PR TITLE
[Sorting Fix] Add Support for DESC NULLS LAST

### DIFF
--- a/__tests__/withPagination.js
+++ b/__tests__/withPagination.js
@@ -236,6 +236,30 @@ test('paginates correctly with boolean asc', async () => {
   expect(result.totalCount).toBe(5);
 });
 
+test('paginates correctly with boolean asc', async () => {
+  await generateTestData();
+
+  const order = [['isValid', 'DESC NULLS LAST']];
+
+  let result = await Test.paginate({ order, limit: 5 });
+
+  // expecting order - [true -> false -> null] -> [ordered by id desc nulls last]
+  expectIdsToEqual(result, [1, 2, 4, 3, 5]);
+  expect(result.totalCount).toBe(5);
+});
+
+test('paginates correctly with boolean asc', async () => {
+  await generateTestData();
+
+  const order = [['isValid', 'DESC NULLS FIRST']];
+
+  let result = await Test.paginate({ order, limit: 5 });
+
+  // expecting order - [null -> true -> false] -> [ordered by id desc nulls first]
+  expectIdsToEqual(result, [3, 5, 1, 2, 4]);
+  expect(result.totalCount).toBe(5);
+});
+
 test('paginates correctly with different order formats', async () => {
   await generateTestData();
 

--- a/__tests__/withPagination.js
+++ b/__tests__/withPagination.js
@@ -236,26 +236,38 @@ test('paginates correctly with boolean asc', async () => {
   expect(result.totalCount).toBe(5);
 });
 
-test('paginates correctly with boolean asc', async () => {
+test('paginates correctly with boolean asc nulls first', async () => {
+  await generateTestData();
+
+  const order = [['isValid', 'ASC NULLS FIRST']];
+
+  let result = await Test.paginate({ order, limit: 5 });
+
+  // expecting order - [false -> true -> null] -> [ordered by id asc]
+  expectIdsToEqual(result, [3, 5, 2, 4, 1]);
+  expect(result.totalCount).toBe(5);
+});
+
+test('paginates correctly with boolean desc nulls last', async () => {
   await generateTestData();
 
   const order = [['isValid', 'DESC NULLS LAST']];
 
   let result = await Test.paginate({ order, limit: 5 });
 
-  // expecting order - [true -> false -> null] -> [ordered by id desc nulls last]
+  // expecting order - [true -> false -> null] -> [ordered by id desc]
   expectIdsToEqual(result, [1, 2, 4, 3, 5]);
   expect(result.totalCount).toBe(5);
 });
 
-test('paginates correctly with boolean asc', async () => {
+test('paginates correctly with boolean desc nulls first', async () => {
   await generateTestData();
 
   const order = [['isValid', 'DESC NULLS FIRST']];
 
   let result = await Test.paginate({ order, limit: 5 });
 
-  // expecting order - [null -> true -> false] -> [ordered by id desc nulls first]
+  // expecting order - [null -> true -> false] -> [ordered by id desc]
   expectIdsToEqual(result, [3, 5, 1, 2, 4]);
   expect(result.totalCount).toBe(5);
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,9 +72,13 @@ const reverseOrder = (order, enforceNullOrder) => {
   return order.map((orderItem) => {
     const keyIndexToUpdate = orderItem.length - 1
 
-    // reverse order for DESC_NULLS_LAST should be ASC_NULLS_FIRST
+    // reverse order for DESC_NULLS_LAST should be ASC_NULLS_FIRST and vice versa
     if(orderItem[keyIndexToUpdate].toUpperCase() === DESC_NULLS_LAST) {
       orderItem[keyIndexToUpdate] = ASC_NULLS_FIRST
+      return orderItem;
+    }
+    if(orderItem[keyIndexToUpdate].toUpperCase() === ASC_NULLS_FIRST) {
+      orderItem[keyIndexToUpdate] = DESC_NULLS_LAST
       return orderItem;
     }
     if(orderItem[keyIndexToUpdate].toLowerCase().split(' ')[0] === 'desc') {
@@ -94,7 +98,6 @@ const getFieldValue = (instance, orderItem) => {
   try {
     const fieldValue = instance[orderItem[0]['as']][orderItem[1]]
     if(!fieldValue) {
-      // when fieldValue is undefined, we try to read from dataValues
       return instance['dataValues'][orderItem[0]['as']][0]['dataValues'][orderItem[1]]
     } else {
       return fieldValue

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,9 @@
 let { Op } = require('sequelize');
 
-const ASC_NULLS_LAST = 'ASC NULLS LAST'
 const DESC_NULLS_FIRST = 'DESC NULLS FIRST'
+const ASC_NULLS_FIRST = 'ASC NULLS FIRST'
+const ASC_NULLS_LAST = 'ASC NULLS LAST'
+const DESC_NULLS_LAST = 'DESC NULLS LAST'
 
 if (!Op) {
   // Support older versions of sequelize
@@ -69,6 +71,12 @@ const normalizeOrder = (order, primaryKeyField, omitPrimaryKeyFromOrder) => {
 const reverseOrder = (order, enforceNullOrder) => {
   return order.map((orderItem) => {
     const keyIndexToUpdate = orderItem.length - 1
+
+    // reverse order for DESC_NULLS_LAST should be ASC_NULLS_FIRST
+    if(orderItem[keyIndexToUpdate].toUpperCase() === DESC_NULLS_LAST) {
+      orderItem[keyIndexToUpdate] = ASC_NULLS_FIRST
+      return orderItem;
+    }
     if(orderItem[keyIndexToUpdate].toLowerCase().split(' ')[0] === 'desc') {
       orderItem[keyIndexToUpdate] = enforceNullOrder ? ASC_NULLS_LAST : 'ASC'
       return orderItem;
@@ -82,13 +90,26 @@ const serializeCursor = (payload) => {
   return Buffer.from(JSON.stringify(payload)).toString('base64');
 };
 
+const getFieldValue = (instance, orderItem) => {
+  try {
+    const fieldValue = instance[orderItem[0]['as']][orderItem[1]]
+    if(!fieldValue) {
+      return instance['dataValues'][orderItem[0]['as']][0]['dataValues'][orderItem[1]]
+    } else {
+      return fieldValue
+    }
+  } catch(e) {
+    return null
+  }
+}
+
 const createCursor = (instance, order) => {
   // order
   // const fields
   const payload = order.map((orderItem) => {
     let field;
     if (typeof orderItem[0] == 'object') {
-      return instance[orderItem[0]['as']][orderItem[1]];
+      return getFieldValue(instance, orderItem)
     } else {
       field = orderItem[0];
     }
@@ -142,11 +163,11 @@ const recursivelyGetPaginationQuery = (order, cursor) => {
     const key = _getColumnName(order);
 
     // https://github.com/goSprinto/sequelize-cursor-pagination#ordering-columns-with-null-values
-    if(cursor[0] === null &&  orderValue === DESC_NULLS_FIRST) {
+    if(cursor[0] === null &&  [DESC_NULLS_FIRST, ASC_NULLS_FIRST].includes(orderValue)) {
       operatorFilter = { [Op.ne]: cursor[0] }
     }
   
-    if(cursor[0] !== null && orderValue === ASC_NULLS_LAST) {
+    if(cursor[0] !== null && [DESC_NULLS_LAST,ASC_NULLS_LAST].includes(orderValue)) {
       operatorFilter = {[Op.or]: [{[Op.is]: null}, operatorFilter] }
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,7 @@ const getFieldValue = (instance, orderItem) => {
   try {
     const fieldValue = instance[orderItem[0]['as']][orderItem[1]]
     if(!fieldValue) {
+      // when fieldValue is undefined, we try to read from dataValues
       return instance['dataValues'][orderItem[0]['as']][0]['dataValues'][orderItem[1]]
     } else {
       return fieldValue


### PR DESCRIPTION
Currently, the cursor pagination wasn't supporting `DESC NULLS LAST` ordering. Added support for it and also handled the reverse order which should be `ASC NULLS FIRST`.

We'd a requirement to sort the results of `Monitor` table based on the `MonitorException` table's `expiresOn` column. The way to achieve this is by passing `order: [[{ model: db.MonitorException, as: 'exceptions' }, 'expiresOn', 'DESC NULLS LAST']]` in the pageDict. But, this wasn't working as expected. On further investigation, found that the object structure of instance is different.

![image](https://github.com/goSprinto/sequelize-cursor-pagination/assets/99247998/63fe738a-058c-42c4-8b00-938d6d78c9eb)
Fixed this bug so that we can order results based on associated table results.

Also, added couple of tests for descending nulls first and last.

Tested pagination to be working totally fine without breaking existing functionality.

The requirement is to sort Special Cases based on Expiry Date with nulls (Never) showing up in the end.

Tested with default page size (50)

https://github.com/goSprinto/sequelize-cursor-pagination/assets/99247998/ed8a6028-7a3b-45a7-811e-936468a1c934

Tested by setting default page size as 1.

https://github.com/goSprinto/sequelize-cursor-pagination/assets/99247998/bc5171cd-0e05-4c99-a60b-0a224b68d59c
